### PR TITLE
fix: add rate limiting to POST /auth/resend-otp (#26)

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -18,6 +18,8 @@ import {
   verifyOtpService,
 } from "../services/auth.service";
 
+const resendCooldowns = new Map<string, number>();
+
 export const registerController = asyncHandler(
   async (req: Request, res: Response) => {
     const body = registerSchema.parse(req.body);
@@ -64,6 +66,17 @@ export const verifyOtpController = asyncHandler(
 export const resendOtpController = asyncHandler(
   async (req: Request, res: Response) => {
     const body = resendOtpSchema.parse(req.body);
+    const { email } = body;
+
+    const now = Date.now();
+    const lastSent = resendCooldowns.get(email);
+    if (lastSent && now - lastSent < 60000) {
+      return res.status(429).json({
+        message: "Too many requests. Please wait before requesting another code.",
+      });
+    }
+    resendCooldowns.set(email, now);
+
     const result = await resendOtpService(body);
 
     return res.status(HTTPSTATUS.OK).json({


### PR DESCRIPTION
## Summary

Fixes **#26**: Add in-memory rate limiting to POST /auth/resend-otp endpoint.

### Problem
The esendOtpController had no rate limiting, allowing attackers to:
- Infinitely loop calls with a valid email address
- Trigger an OTP email on each request
- Abuse the Resend email sending quota

### Solution
- Added Map<string, number> cooldown tracker at module level (esendCooldowns)
- Each email address is limited to **1 request per 60 seconds**
- Returns HTTP **429** with clear message when limit exceeded
- Lightweight in-memory implementation, no Redis dependency needed

### Changes
- **File**: src/controllers/auth.controller.ts
  - Added const resendCooldowns = new Map<string, number>() after imports (line 21)
  - Added cooldown check + update logic inside esendOtpController (lines 69-78)

---

If you need more quick fixes like this, feel free to reach out!