### PR TITLE
fix: Correct typo 'Transacton' → 'Transaction' in API response

### DIFF
--- a/src/controllers/transaction.controller.ts
+++ b/src/controllers/transaction.controller.ts
@@ -29,7 +29,7 @@ export const createTransactionController = asyncHandler(
     const transaction = await createTransactionService(body, userId);
 
     return res.status(HTTPSTATUS.CREATED).json({
-      message: "Transacton created successfully",
+      message: "Transaction created successfully",
       transaction,
     });
   }


### PR DESCRIPTION
## Summary
Fixes #35 — The `createTransactionController` returns `"Transacton created successfully"` (missing 'i').

## Root Cause
Typo in the success message string at `src/controllers/transaction.controller.ts:32`. The misspelled string is included in every successful transaction creation response.

## Fix
Changed `"Transacton created successfully"` → `"Transaction created successfully"` (+1 -1 character).

## Testing
- Verified the exact string exists in source before patching
- Confirmed fix is a single character insertion (no side effects)
- No other occurrences of "Transacton" in the codebase