### PR TITLE
fix(backend): Clear recurrence fields when disabling recurring transaction

### DIFF
--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -12,7 +12,7 @@ import { receiptPrompt } from "../utils/prompt";
 
 export const createTransactionService = async (
   body: CreateTransactionType,
-  userId: string
+  userId: string,
 ) => {
   let nextRecurringDate: Date | undefined;
   const currentDate = new Date();
@@ -20,7 +20,7 @@ export const createTransactionService = async (
   if (body.isRecurring && body.recurringInterval) {
     const calulatedDate = calculateNextOccurrence(
       body.date,
-      body.recurringInterval
+      body.recurringInterval,
     );
 
     nextRecurringDate =
@@ -53,7 +53,7 @@ export const getAllTransactionService = async (
   pagination: {
     pageSize: number;
     pageNumber: number;
-  }
+  },
 ) => {
   const { keyword, type, recurringStatus } = filters;
 
@@ -107,7 +107,7 @@ export const getAllTransactionService = async (
 
 export const getTransactionByIdService = async (
   userId: string,
-  transactionId: string
+  transactionId: string,
 ) => {
   const transaction = await TransactionModel.findOne({
     _id: transactionId,
@@ -120,7 +120,7 @@ export const getTransactionByIdService = async (
 
 export const duplicateTransactionService = async (
   userId: string,
-  transactionId: string
+  transactionId: string,
 ) => {
   const transaction = await TransactionModel.findOne({
     _id: transactionId,
@@ -148,7 +148,7 @@ export const duplicateTransactionService = async (
 export const updateTransactionService = async (
   userId: string,
   transactionId: string,
-  body: UpdateTransactionType
+  body: UpdateTransactionType,
 ) => {
   const existingTransaction = await TransactionModel.findOne({
     _id: transactionId,
@@ -163,12 +163,20 @@ export const updateTransactionService = async (
   const date =
     body.date !== undefined ? new Date(body.date) : existingTransaction.date;
 
-  const recurringInterval =
-    body.recurringInterval || existingTransaction.recurringInterval;
+  let recurringInterval:
+    | "DAILY"
+    | "WEEKLY"
+    | "MONTHLY"
+    | "YEARLY"
+    | null
+    | undefined =
+    body.recurringInterval ?? existingTransaction.recurringInterval;
+  let nextRecurringDate: Date | undefined | null = null;
 
-  let nextRecurringDate: Date | undefined;
-
-  if (isRecurring && recurringInterval) {
+  if (isRecurring === false) {
+    recurringInterval = null;
+    nextRecurringDate = null;
+  } else if (isRecurring && recurringInterval) {
     const calulatedDate = calculateNextOccurrence(date, recurringInterval);
 
     nextRecurringDate =
@@ -197,7 +205,7 @@ export const updateTransactionService = async (
 
 export const deleteTransactionService = async (
   userId: string,
-  transactionId: string
+  transactionId: string,
 ) => {
   const deleted = await TransactionModel.findByIdAndDelete({
     _id: transactionId,
@@ -210,7 +218,7 @@ export const deleteTransactionService = async (
 
 export const bulkDeleteTransactionService = async (
   userId: string,
-  transactionIds: string[]
+  transactionIds: string[],
 ) => {
   const result = await TransactionModel.deleteMany({
     _id: { $in: transactionIds },
@@ -228,7 +236,7 @@ export const bulkDeleteTransactionService = async (
 
 export const bulkTransactionService = async (
   userId: string,
-  transactions: CreateTransactionType[]
+  transactions: CreateTransactionType[],
 ) => {
   try {
     const bulkOps = transactions.map((tx) => ({
@@ -260,7 +268,7 @@ export const bulkTransactionService = async (
 };
 
 export const scanReceiptService = async (
-  file: Express.Multer.File | undefined
+  file: Express.Multer.File | undefined,
 ) => {
   if (!file) throw new BadRequestException("No file uploaded");
 


### PR DESCRIPTION
## Summary
Fixes an issue where updating a recurring transaction to non-recurring did not clear recurrence-related fields.

## Related issues

- Closes #51


## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] backend
- [ ] client (web)
- [ ] mobile (React Native)
- [ ] CI/CD
- [ ] docs

## How to test

1. Go to the Transactions page.
2. Create a recurring transaction.
3. Update the same transaction and change it from recurring to non-recurring (isRecurring = false).
4. Open the Network tab or check the database record.
5. Observe:
   -isRecurring : false
   -recurringInterval : null
   -nextRecurringDate : null
## Media

- [x] I attached screenshots or recordings when the change affects the UI or visible behavior.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

Paste relevant command output:

```
# backend
npm run build && npm test --if-present

# client
npm run build && npm run lint

# mobile
npx tsc --noEmit
```

## Screenshots or recordings

### 2. When user updates transaction and sets recurring to false

| Before | After |
|--------|------|
| <img width="204" height="36" alt="image" src="https://github.com/user-attachments/assets/1ea3dce2-02d1-4068-bd9d-053397b1ca36" />| <img width="195" height="55" alt="image" src="https://github.com/user-attachments/assets/6f53b501-d670-45ab-94a3-9d0e3d3f6e0d" /> |

## Breaking changes

- [x] No
- [ ] Yes (describe below)

If yes, describe migration steps.

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [x] I added or updated tests where needed.
- [x] I updated documentation where needed.
- [x] I removed secrets and sensitive information.
