### PR TITLE
fix: Enforce password strength validation in auth validator

### DIFF
--- a/src/validators/auth.validator.ts
+++ b/src/validators/auth.validator.ts
@@ -7,7 +7,13 @@ export const emailSchema = z
   .min(1)
   .max(255);
 
-export const passwordSchema = z.string().trim().min(4);
+export const passwordSchema = 
+z.string()
+.trim()
+.min(8,"Password must be at least 8 characters")
+.regex(/[A-Z]/,"Must contain uppercase letter")
+.regex(/[0-9]/,"Must contain a number")
+.regex(/[^A-Za-z0-9]/,"Must contain special character")
 
 export const registerSchema = z.object({
   name: z.string().trim().min(1).max(255),


### PR DESCRIPTION
## Summary
passwordSchema was only checking minimum 4 characters with no 
complexity rules. Anyone could register with a password like "abcd".

Fixed by requiring minimum 8 characters with at least one uppercase 
letter, one number, and one special character.

Only one file changed because passwordSchema is shared across 
registerSchema and resetPasswordSchema — both are fixed automatically.

## Related issues
- Related to voiceyBill/voiceyBill-web#57

## Issue template used
- [x] Bug report

## Type of change
- [x] fix

## Scope
- [x] backend

## How to test
1. Send POST request to /api/auth/register with weak password e.g. "abcdef"
2. Should return 400 error
3. Send same request with "Test@1234"
4. Should succeed

## Media
- [x] I linked the issue that motivated this change

## Validation output
npm run build — success (TypeScript compiled with no errors)
## Breaking changes
- [x] No

## Checklist
- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [x] I removed secrets and sensitive information.