### PR TITLE
chore(vscode): add editor settings and extension recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,6 @@ logs/
 # ─── OS / Editor ──────────────────────────────────────────────────────────────
 .DS_Store
 .idea/
-.vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "ms-vscode.vscode-typescript-next",
+    "dbaeumer.vscode-eslint",
+    "mongodb.mongodb-vscode"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+  "editor.formatOnSave": true,
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "files.eol": "\n",
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.vscode/settings.json` to enforce consistent formatting: 2-space indentation, LF line endings, format on save, trim trailing whitespace, and insert final newline
- Adds `.vscode/extensions.json` with recommended extensions for TypeScript and MongoDB development
- Updates `.gitignore` to track `.vscode/settings.json` and `.vscode/extensions.json`

## Related issues

N/A

## Type of change

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [x] chore

## Scope

- [ ] backend
- [ ] client (web)
- [ ] mobile (React Native)
- [ ] CI/CD
- [x] docs

## How to test

1. Clone the repo and open in VSCode
2. VSCode should prompt to install recommended extensions
3. Edit any `.ts` file and save — it should auto-format with 2-space indentation and LF line endings

## Validation output

```
# Configuration files only — no build output required
```

## Screenshots or recordings

N/A

## Breaking changes

- [x] No
- [ ] Yes (describe below)

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [x] I updated documentation where needed.
- [x] I removed secrets and sensitive information.
