### PR TITLE
fix(auth): Relax login password validation

### DIFF
--- a/src/validators/auth.validator.ts
+++ b/src/validators/auth.validator.ts
@@ -7,13 +7,13 @@ export const emailSchema = z
   .min(1)
   .max(255);
 
-export const passwordSchema = 
-z.string()
-.trim()
-.min(8,"Password must be at least 8 characters")
-.regex(/[A-Z]/,"Must contain uppercase letter")
-.regex(/[0-9]/,"Must contain a number")
-.regex(/[^A-Za-z0-9]/,"Must contain special character")
+export const passwordSchema = z
+  .string()
+  .trim()
+  .min(8, "Password must be at least 8 characters")
+  .regex(/[A-Z]/, "Must contain uppercase letter")
+  .regex(/[0-9]/, "Must contain a number")
+  .regex(/[^A-Za-z0-9]/, "Must contain special character");
 
 export const registerSchema = z.object({
   name: z.string().trim().min(1).max(255),
@@ -23,12 +23,15 @@ export const registerSchema = z.object({
 
 export const loginSchema = z.object({
   email: emailSchema,
-  password: passwordSchema,
+  password: z.string().trim().min(1, "Password is required"),
 });
 
 export const verifyOtpSchema = z.object({
   email: emailSchema,
-  otp: z.string().trim().regex(/^\d{6}$/, "OTP must be a 6-digit code"),
+  otp: z
+    .string()
+    .trim()
+    .regex(/^\d{6}$/, "OTP must be a 6-digit code"),
 });
 
 export const resendOtpSchema = z.object({
@@ -41,7 +44,10 @@ export const forgotPasswordSchema = z.object({
 
 export const resetPasswordSchema = z.object({
   email: emailSchema,
-  otp: z.string().trim().regex(/^\d{6}$/, "OTP must be a 6-digit code"),
+  otp: z
+    .string()
+    .trim()
+    .regex(/^\d{6}$/, "OTP must be a 6-digit code"),
   password: passwordSchema,
 });
 


### PR DESCRIPTION
## Summary
Fixed login validation issue where the login schema incorrectly reused the strict `passwordSchema` intended for registration/password creation.

This prevented legacy users from logging in if their existing passwords did not satisfy newly introduced complexity requirements.

The login validator now only checks that the password field is present and non-empty.


## Related issues

- Closes #64


## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] backend
- [ ] client (web)
- [ ] mobile (React Native)
- [ ] CI/CD
- [ ] docs

## How to test
1. Your local repo is fully up to date with remote repositry
2. Go to login page
3. Enter valid credential of the account that is registered before strict policy. You will logged in successfully.

## Media

- [x] I attached screenshots or recordings when the change affects the UI or visible behavior.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

Paste relevant command output:

```
# backend
npm run build && npm test --if-present

# client
npm run build && npm run lint

# mobile
npx tsc --noEmit
```

## Screenshots or recordings

| Before | After |
|------------|------------|
|<img width="495" height="409" alt="image" src="https://github.com/user-attachments/assets/143d3929-4f3f-49fe-aeb2-024774bb8c1f" />|<img width="495" height="409" alt="image" src="https://github.com/user-attachments/assets/7b11bd33-afad-4c6d-96ad-69cfbeee3e7b" />|
|<img width="522" height="138" alt="Image" src="https://github.com/user-attachments/assets/e8eab802-bead-4029-bec9-80afef3f7302" />|<img width="928" height="125" alt="image" src="https://github.com/user-attachments/assets/31a1459f-ade1-4e02-9dce-ae2610a1c3a2" />|




## Breaking changes

- [x] No
- [ ] Yes (describe below)

If yes, describe migration steps.

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [x] I added or updated tests where needed.
- [x] I updated documentation where needed.
- [x] I removed secrets and sensitive information.
