### PR TITLE
fix(auth): Enforce registration password rules during password change

### DIFF
--- a/src/middlewares/errorHandler.middleware.ts
+++ b/src/middlewares/errorHandler.middleware.ts
@@ -11,9 +11,16 @@ const formatZodError = (res: Response, error: z.ZodError) => {
     field: err.path.join("."),
     message: err.message,
   }));
+
+  const hasPasswordError = errors.some(
+    (err) => err.field === "password" || err.field === "newPassword",
+  );
+
   return res.status(HTTPSTATUS.BAD_REQUEST).json({
-    message: "Validation failed",
-    errors: errors,
+    message: hasPasswordError
+      ? "Password must contain at least 8 characters, an uppercase letter, a number, and a special character"
+      : "Validation failed",
+    errors,
     errorCode: ErrorCodeEnum.VALIDATION_ERROR,
   });
 };
@@ -37,14 +44,15 @@ export const errorHandler: ErrorRequestHandler = (
   error,
   req,
   res,
-  next
+  next,
 ): any => {
-  const errorInfo = error && typeof error === "object"
-    ? {
-      message: (error as Error).message,
-      stack: (error as Error).stack,
-    }
-    : error;
+  const errorInfo =
+    error && typeof error === "object"
+      ? {
+          message: (error as Error).message,
+          stack: (error as Error).stack,
+        }
+      : error;
 
   console.error("Error occurred on PATH:", req.path, "Error:", errorInfo);
 

--- a/src/validators/user.validator.ts
+++ b/src/validators/user.validator.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { isValidCurrencyCode } from "../utils/currency.constants";
+import { passwordSchema } from "./auth.validator";
 
 export const updateUserSchema = z.object({
   name: z.string().trim().min(1).max(255).optional(),
@@ -16,7 +17,7 @@ export type UpdateUserType = z.infer<typeof updateUserSchema>;
 
 export const changePasswordSchema = z.object({
   currentPassword: z.string().min(1, "Current password is required"),
-  newPassword: z.string().min(6, "Password must be at least 6 characters"),
+  newPassword: passwordSchema,
 });
 
 export const deleteAccountSchema = z.object({


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency in password policy enforcement between user registration and password change operations.
## Related issues

- Closes #101


## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] backend
- [ ] client (web)
- [ ] mobile (React Native)
- [ ] CI/CD
- [ ] docs

## How to test

1.Login your account with strong password.
2 Go to chenge password section.
3.Create week password.
4. Password will not change successfully.
## Media

- [x] I attached screenshots or recordings when the change affects the UI or visible behavior.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

Paste relevant command output:

```
# backend
npm run build && npm test --if-present

# client
npm run build && npm run lint

# mobile
npx tsc --noEmit
```

## Screenshots or recordings

<img width="655" height="516" alt="image" src="https://github.com/user-attachments/assets/88b45ceb-0ddc-4880-b534-0acefdf3c7a8" />


## Breaking changes

- [x] No
- [ ] Yes (describe below)

If yes, describe migration steps.

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [x] I added or updated tests where needed.
- [x] I updated documentation where needed.
- [x] I removed secrets and sensitive information.
