### PR TITLE
fix(backend): Merge fallback currencies with provider response to include PKR

### DIFF
--- a/src/services/exchange-rate.service.ts
+++ b/src/services/exchange-rate.service.ts
@@ -83,12 +83,19 @@ export class ExchangeRateService {
     );
   }
 
-  async getSupportedCurrencies(): Promise<Record<string, string>> {
+ async getSupportedCurrencies(): Promise<Record<string, string>> {
     try {
       const response = await axios.get(`${PROVIDER_BASE_URL}/currencies`, {
         timeout: 5000,
       });
-      return response.data;
+      const providerCurrencies = response.data;
+      const merged = { ...providerCurrencies };
+      for (const code of FALLBACK_SUPPORTED_CURRENCIES) {
+        if (!merged[code]) {
+          merged[code] = code;
+        }
+      }
+      return merged;
     } catch (error: any) {
       console.warn(
         "Failed to fetch currencies from provider, using fallback:",


### PR DESCRIPTION
## Summary
The getSupportedCurrencies() function was only returning currencies 
from the Frankfurter API provider, which does not include PKR. 
The FALLBACK_SUPPORTED_CURRENCIES list already had PKR defined but 
was only used when the API call failed completely. This fix merges 
the provider response with the fallback list so PKR always appears 
in the currency dropdown.

## Related issues
- Closes #133

## Issue template used
- [x] Bug report

## Type of change
- [x] fix

## Scope
- [x] backend

## How to test
1. Run the backend server locally
2. Call GET /api/currency/supported
3. Verify PKR appears in the response
4. Open the frontend Add Transaction modal
5. Click the currency dropdown and verify PKR is listed

## Media
- [x] I linked the issue or discussion that motivated this change.

## Validation output
npm run build && npm test --if-present

## Screenshots or recordings
N/A - backend only change, no UI difference beyond PKR appearing in dropdown.

## Breaking changes
- [x] No

## Checklist
- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [x] I removed secrets and sensitive information.