### PR TITLE
fix(validation): Allow decimal amounts less than 1 in transactions

### DIFF
--- a/src/validators/transaction.validator.ts
+++ b/src/validators/transaction.validator.ts
@@ -14,7 +14,7 @@ export const baseTransactionSchema = z.object({
   type: z.enum([TransactionTypeEnum.INCOME, TransactionTypeEnum.EXPENSE], {
     message: "Transaction type must either INCOME or EXPENSE",
   }),
-  amount: z.number().positive("Amount must be postive").min(1),
+  amount: z.number().positive("Amount must be positive").min(0.01, "Amount must be at least 0.01"),
   category: z.string().min(1, "Category is required"),
   date: z
     .union([z.string().datetime({ message: "Invalid date string" }), z.date()])


### PR DESCRIPTION
## Summary
Changed amount validation in `baseTransactionSchema` 
from `min(1)` to `min(0.01)` to allow decimal amounts 
less than 1 (e.g. $0.75 USD). Previously, any amount 
less than 1 was rejected with "Number must be greater 
than or equal to 1" error.

## Related issues

Closes voiceyBill/voiceyBill-web#153

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] backend
- [ ] client (web)
- [ ] mobile (React Native)
- [ ] CI/CD
- [ ] docs

## How to test

1. Run backend: `npm run dev`
2. Connect frontend to `http://localhost:8000/api`
3. Create a new transaction with amount `$0.75`
4. Verify transaction creates successfully ✅
5. Try amount `0` — verify it is rejected ✅
6. Try negative amount — verify it is rejected ✅

## Media

- [ ] I attached screenshots or recordings when the change affects the UI or visible behavior.
- [x] I linked the issue that motivated this change.

## Validation output

npm run build && npm test --if-present

```
# backend
npm run build && npm test --if-present

# client
npm run build && npm run lint

# mobile
npx tsc --noEmit
```

## Screenshots or recordings
Before

<img width="1373" height="635" alt="image" src="https://github.com/user-attachments/assets/1080b846-39c7-4df3-b394-4093d033bcb0" />



After
<img width="1073" height="557" alt="image" src="https://github.com/user-attachments/assets/2fac2d20-bc2e-439b-96ff-60e2effac1de" />

<img width="1183" height="308" alt="image" src="https://github.com/user-attachments/assets/ab766846-a2c3-4efe-a74a-e114d85c4e62" />
<img width="366" height="917" alt="image" src="https://github.com/user-attachments/assets/68f6bf49-33d7-4363-a8f1-e081173f3127" />




## Breaking changes
- [x] No
- [ ] Yes (describe below)

If yes, describe migration steps.

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [x] I added or updated tests where needed.
- [x] I updated documentation where needed.
- [x] I removed secrets and sensitive information.