### PR TITLE
fix: Enforce monthly budget limits and return uncapped usage percentage

### DIFF
--- a/src/dto/budget.dto.ts
+++ b/src/dto/budget.dto.ts
@@ -117,7 +117,7 @@ export async function toBudgetSummaryDTO(
         limit: categoryLimit.limit,
         spent,
         remaining,
-        usagePercentage: Number(Math.min(usagePercentage, 100)),
+        usagePercentage: Number(usagePercentage),
         exceeded,
       };
     }
@@ -148,7 +148,7 @@ export async function toBudgetSummaryDTO(
     totalBudget: budget.totalBudget,
     spent: totalSpent,
     remaining,
-    usagePercentage: Number(Math.min(usagePercentage, 100)),
+    usagePercentage: Number(usagePercentage),
     exceeded,
     categories,
     alerts,

--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -2,6 +2,8 @@ import TransactionModel, {
   TransactionTypeEnum,
 } from "../models/transaction.model";
 import { BadRequestException, NotFoundException } from "../utils/app-error";
+import BudgetModel from "../models/budget.model";
+import { ErrorCodeEnum } from "../enums/error-code.enum";
 import { calculateNextOccurrence } from "../utils/helper";
 import {
   CreateTransactionType,
@@ -90,6 +92,65 @@ export const createTransactionService = async (
     Number(body.amount),
     body.currency,
   );
+
+  if (body.type === TransactionTypeEnum.EXPENSE) {
+    const transactionDate = new Date(body.date);
+    const month = transactionDate.getMonth() + 1;
+    const year = transactionDate.getFullYear();
+
+    const budget = await BudgetModel.findOne({
+      userId,
+      month,
+      year,
+    });
+
+    if (budget) {
+      // Calculate current total spent for this month/year
+      const startDate = new Date(year, month - 1, 1);
+      const endDate = new Date(year, month, 0, 23, 59, 59, 999);
+      const transactions = await TransactionModel.find({
+        userId,
+        type: TransactionTypeEnum.EXPENSE,
+        date: {
+          $gte: startDate,
+          $lte: endDate,
+        },
+      });
+
+      const totalSpent = transactions.reduce((sum, t) => sum + (typeof t.amount === 'number' ? t.amount : parseFloat(String(t.amount || 0))), 0);
+
+      if (totalSpent + currencyFields.amount > budget.totalBudget) {
+        const remaining = budget.totalBudget - totalSpent;
+        const remainingStr = remaining < 0 ? `-$${Math.abs(remaining).toFixed(2)}` : `$${remaining.toFixed(2)}`;
+        throw new BadRequestException(
+          `Transaction exceeds monthly budget of $${budget.totalBudget}. Remaining: ${remainingStr}`,
+          ErrorCodeEnum.BUDGET_INVALID_AMOUNT
+        );
+      }
+
+      // Check category limit
+      if (body.category) {
+        const normalizedCategory = body.category.trim().toLowerCase().replace(/\s+/g, "_");
+        const categoryLimit = budget.categoryLimits.find(
+          (c) => c.category.trim().toLowerCase().replace(/\s+/g, "_") === normalizedCategory
+        );
+        if (categoryLimit) {
+          const categorySpent = transactions
+            .filter((t) => t.category.trim().toLowerCase().replace(/\s+/g, "_") === normalizedCategory)
+            .reduce((sum, t) => sum + (typeof t.amount === 'number' ? t.amount : parseFloat(String(t.amount || 0))), 0);
+
+          if (categorySpent + currencyFields.amount > categoryLimit.limit) {
+            const remaining = categoryLimit.limit - categorySpent;
+            const remainingStr = remaining < 0 ? `-$${Math.abs(remaining).toFixed(2)}` : `$${remaining.toFixed(2)}`;
+            throw new BadRequestException(
+              `Transaction exceeds category limit for ${body.category}. Remaining: ${remainingStr}`,
+              ErrorCodeEnum.BUDGET_INVALID_AMOUNT
+            );
+          }
+        }
+      }
+    }
+  }
 
   const transaction = await TransactionModel.create({
     ...body,
@@ -296,6 +357,70 @@ export const updateTransactionService = async (
     };
   }
 
+  const targetType = body.type || existingTransaction.type;
+  if (targetType === TransactionTypeEnum.EXPENSE) {
+    const transactionDate = new Date(date);
+    const month = transactionDate.getMonth() + 1;
+    const year = transactionDate.getFullYear();
+
+    const budget = await BudgetModel.findOne({
+      userId,
+      month,
+      year,
+    });
+
+    if (budget) {
+      const targetAmount = currencyUpdate.amount !== undefined ? currencyUpdate.amount : existingTransaction.amount;
+
+      // Calculate current total spent for this month/year, excluding this transaction
+      const startDate = new Date(year, month - 1, 1);
+      const endDate = new Date(year, month, 0, 23, 59, 59, 999);
+      const transactions = await TransactionModel.find({
+        userId,
+        _id: { $ne: transactionId },
+        type: TransactionTypeEnum.EXPENSE,
+        date: {
+          $gte: startDate,
+          $lte: endDate,
+        },
+      });
+
+      const totalSpent = transactions.reduce((sum, t) => sum + (typeof t.amount === 'number' ? t.amount : parseFloat(String(t.amount || 0))), 0);
+
+      if (totalSpent + targetAmount > budget.totalBudget) {
+        const remaining = budget.totalBudget - totalSpent;
+        const remainingStr = remaining < 0 ? `-$${Math.abs(remaining).toFixed(2)}` : `$${remaining.toFixed(2)}`;
+        throw new BadRequestException(
+          `Transaction exceeds monthly budget of $${budget.totalBudget}. Remaining: ${remainingStr}`,
+          ErrorCodeEnum.BUDGET_INVALID_AMOUNT
+        );
+      }
+
+      // Check category limit
+      const category = body.category || existingTransaction.category;
+      if (category) {
+        const normalizedCategory = category.trim().toLowerCase().replace(/\s+/g, "_");
+        const categoryLimit = budget.categoryLimits.find(
+          (c) => c.category.trim().toLowerCase().replace(/\s+/g, "_") === normalizedCategory
+        );
+        if (categoryLimit) {
+          const categorySpent = transactions
+            .filter((t) => t.category.trim().toLowerCase().replace(/\s+/g, "_") === normalizedCategory)
+            .reduce((sum, t) => sum + (typeof t.amount === 'number' ? t.amount : parseFloat(String(t.amount || 0))), 0);
+
+          if (categorySpent + targetAmount > categoryLimit.limit) {
+            const remaining = categoryLimit.limit - categorySpent;
+            const remainingStr = remaining < 0 ? `-$${Math.abs(remaining).toFixed(2)}` : `$${remaining.toFixed(2)}`;
+            throw new BadRequestException(
+              `Transaction exceeds category limit for ${category}. Remaining: ${remainingStr}`,
+              ErrorCodeEnum.BUDGET_INVALID_AMOUNT
+            );
+          }
+        }
+      }
+    }
+  }
+
   existingTransaction.set({
     ...(body.title && { title: body.title }),
     ...(body.description && { description: body.description }),
@@ -442,8 +567,8 @@ export const scanReceiptService = async (
 
     const currency =
       typeof data.currency === "string" &&
-      data.currency.trim().toUpperCase() !== "DEFAULT" &&
-      data.currency.trim().length === 3
+        data.currency.trim().toUpperCase() !== "DEFAULT" &&
+        data.currency.trim().length === 3
         ? data.currency.trim().toUpperCase()
         : undefined;
 


### PR DESCRIPTION
## Summary

This PR addresses the backend issues related to budget enforcement and usage calculation:
1. **Transaction Budget Limit Enforcement**: Added middleware validation checks in `createTransactionService` and `updateTransactionService` to reject transactions/updates that exceed either the total monthly budget or specific category limits.
2. **Uncapped Usage Percentage**: Removed the `Math.min(..., 100)` cap from `usagePercentage` calculations in the `toBudgetSummaryDTO` so that the client receives the actual overspent percentages (e.g. `150%` instead of being artificially capped at `100%`).

## Related issues

- Closes #136 

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [ ] ui (components / pages)
- [ ] design (tokens / styles)
- [x] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Set a monthly budget of `$200` for a user.
2. Attempt to create a transaction of `$300` using `/api/transaction/create`. Verify that the API returns a `400 Bad Request` with error code `BUDGET_INVALID_AMOUNT`.
3. Set a category limit of `$50` on `"dining"`. Attempt to create a dining transaction of `$60`. Verify the validation correctly rejects it.
4. Run existing test suites.

## Media
<img width="788" height="401" alt="Screenshot 2026-06-08 201604" src="https://github.com/user-attachments/assets/98e78e5d-c09a-4669-9c6d-036ac84e257b" />

<img width="951" height="415" alt="Screenshot 2026-06-08 201809" src="https://github.com/user-attachments/assets/62df5514-6134-457b-aec2-ffa8fe9b81d5" />


- [x] I linked the issue or discussion that motivated this change.

## Validation output

Paste command outputs:

```bash
npm run lint
npm run build
