### PR TITLE
fix(google-auth): Move GOOGLE_CLIENT_ID guard to request-time to prev…

### DIFF
--- a/src/config/google-oauth.config.ts
+++ b/src/config/google-oauth.config.ts
@@ -1,21 +1,67 @@
 import { OAuth2Client } from "google-auth-library";
 import { Env } from "./env.config";
 
-if (!Env.GOOGLE_CLIENT_ID) {
-  throw new Error("GOOGLE_CLIENT_ID environment variable is not set");
-}
+// ─── Why the module-level throw was removed ───────────────────────────────────
+//
+// The original code threw at module-load time if GOOGLE_CLIENT_ID was missing.
+// On Vercel (serverless), this crashes the function BEFORE Express is running,
+// so the Express errorHandler never fires. Vercel returns its own raw error
+// response (not JSON), RTK Query fails to parse it, and the mobile app shows
+// the generic "Google sign-in failed" fallback instead of a useful message.
+//
+// Fix: move the guard into verifyGoogleIdToken() so the error is thrown inside
+// a request handler, Express can catch it, and the client receives a proper
+// JSON response with a readable message.
+// ─────────────────────────────────────────────────────────────────────────────
 
-export const googleAuthClient = new OAuth2Client({
-  clientId: Env.GOOGLE_CLIENT_ID,
-});
+// OAuth2Client does not need a clientId in the constructor when an explicit
+// audience list is passed to verifyIdToken(). Keeping the constructor argument
+// when the value is present is harmless and retains the original behaviour.
+export const googleAuthClient = new OAuth2Client(
+  Env.GOOGLE_CLIENT_ID || undefined,
+);
 
+// ─── Accepted token audiences ─────────────────────────────────────────────────
+//
+// Google ID tokens include an `aud` claim equal to the OAuth client ID that
+// issued them.
+//
+// • @react-native-google-signin/google-signin on Android
+//     configure({ webClientId }) → aud = GOOGLE_CLIENT_ID (web client)
+//
+// • expo-auth-session legacy flow / web login
+//     aud = GOOGLE_CLIENT_ID (web client)
+//
+// • Future iOS native SDK flow
+//     aud = GOOGLE_IOS_CLIENT_ID
+//
+// All three IDs are included so the same endpoint handles every platform.
+// ─────────────────────────────────────────────────────────────────────────────
 const googleClientAudiences = [
   Env.GOOGLE_CLIENT_ID,
   Env.GOOGLE_ANDROID_CLIENT_ID,
   Env.GOOGLE_IOS_CLIENT_ID,
-].filter((clientId): clientId is string => Boolean(clientId?.trim()));
+].filter((id): id is string => Boolean(id?.trim()));
 
 export const verifyGoogleIdToken = async (idToken: string) => {
+  // ── Guard: configuration check at request time ──────────────────────────────
+  // Checked here (not at module load) so Express can return a proper JSON 500
+  // instead of Vercel's raw function-crash error page.
+  if (!Env.GOOGLE_CLIENT_ID) {
+    throw new Error(
+      "Server configuration error: GOOGLE_CLIENT_ID is not set. " +
+        "Set it to the Web application client ID in the hosting environment.",
+    );
+  }
+
+  if (googleClientAudiences.length === 0) {
+    throw new Error(
+      "Server configuration error: no Google client IDs configured. " +
+        "Set GOOGLE_CLIENT_ID in the hosting environment.",
+    );
+  }
+
+  // ── Verify the token ────────────────────────────────────────────────────────
   try {
     const ticket = await googleAuthClient.verifyIdToken({
       idToken,
@@ -23,20 +69,24 @@ export const verifyGoogleIdToken = async (idToken: string) => {
     });
 
     const payload = ticket.getPayload();
-
-    if (!payload) {
-      throw new Error("Invalid token payload");
-    }
+    if (!payload) throw new Error("Google token returned an empty payload.");
 
     return {
       googleId: payload.sub,
-      email: payload.email || "",
-      name: payload.name || "",
-      picture: payload.picture || null,
-      emailVerified: payload.email_verified || false,
+      email: payload.email ?? "",
+      name: payload.name ?? "",
+      picture: payload.picture ?? null,
+      emailVerified: payload.email_verified ?? false,
     };
-  } catch (error) {
-    console.error("Google token verification failed:", error);
+  } catch (error: any) {
+    // Surface the original Google library error message so the service layer
+    // can forward a useful reason to the client (e.g. "audience mismatch").
+    console.error("[google-oauth] token verification failed:", {
+      message: error?.message,
+      audiences: googleClientAudiences.map((id) =>
+        id ? `${id.slice(0, 20)}…` : "(empty)",
+      ),
+    });
     throw error;
   }
 };


### PR DESCRIPTION
…ent Vercel crash

Problem 1 — startup crash causing non-JSON error response:
  The original module-level throw fired before Express was running.
  On Vercel serverless, this crashes the function before the Express
  errorHandler can intercept it, so Vercel returns its own raw error
  page (not JSON). RTK Query fails to parse the response, the mobile
  app cannot extract a message, and shows the generic fallback
  'Google sign-in failed. Please try again.'

  Fix: remove the module-level throw. Move the GOOGLE_CLIENT_ID and
  audience-list guard into verifyGoogleIdToken() so it fires inside a
  live request → Express catches it → proper JSON 500 is returned →
  the mobile app shows the real error message.

Problem 2 — audience comment clarification:
  Added clear inline docs explaining which client ID corresponds to
  which OAuth flow (native Android SDK, web login, future iOS SDK).
  With @react-native-google-signin/google-signin the idToken always
  has aud = GOOGLE_CLIENT_ID (web client), not the Android client ID.
  GOOGLE_CLIENT_ID on Vercel must be the Web application client ID:
    747929251420-pda33jplvlh7votecms914khkh215rb9.apps.googleusercontent.com

  The Android client ID (GOOGLE_ANDROID_CLIENT_ID) is still listed in
  the audience array for completeness and future flexibility but is not
  the aud value produced by the native SDK.

Also: surface the original google-auth-library error message in the server log so the audience values are visible for quick diagnosis.

## Summary

Describe what changed and why.

## Related issues

- Closes #
- Related to #

## Issue template used

- [ ] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [ ] backend
- [ ] client (web)
- [ ] mobile (React Native)
- [ ] CI/CD
- [ ] docs

## How to test

List steps to validate this change locally.

## Media

- [ ] I attached screenshots or recordings when the change affects the UI or visible behavior.
- [ ] I linked the issue or discussion that motivated this change.

## Validation output

Paste relevant command output:

```
# backend
npm run build && npm test --if-present

# client
npm run build && npm run lint

# mobile
npx tsc --noEmit
```

## Screenshots or recordings

Attach screenshots for any UI-related changes (web or mobile).

## Breaking changes

- [ ] No
- [ ] Yes (describe below)

If yes, describe migration steps.

## Checklist

- [ ] PR title follows Conventional Commits style.
- [ ] I used the PR template fully and did not leave required sections blank.
- [ ] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [ ] I removed secrets and sensitive information.
