### PR TITLE
fix(server): Group categories case-insensitively and calculate percentage with decimals

### DIFF
--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -394,7 +394,7 @@ export const expensePieChartBreakdownService = async (
     },
     {
       $group: {
-        _id: "$category",
+        _id: { $toLower: "$category" },
         value: { $sum: { $abs: "$amount" } },
       },
     },
@@ -457,7 +457,7 @@ export const expensePieChartBreakdownService = async (
                           100,
                         ],
                       },
-                      0,
+                      2,
                     ],
                   },
                 ],
@@ -479,6 +479,7 @@ export const expensePieChartBreakdownService = async (
     totalSpent: convertToDollarUnit(data.totalSpent),
     breakdown: data.breakdown.map((item: any) => ({
       ...item,
+      name: item.name ? item.name.split(" ").map((w: string) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join(" ") : "",
       value: convertToDollarUnit(item.value),
     })),
   };

--- a/src/services/report.service.ts
+++ b/src/services/report.service.ts
@@ -131,7 +131,7 @@ export const generateReportService = async (
           },
           {
             $group: {
-              _id: "$category",
+              _id: { $toLower: "$category" },
               total: { $sum: { $abs: "$amount" } },
             },
           },
@@ -190,10 +190,11 @@ export const generateReportService = async (
 
   const byCategory = categories.reduce(
     (acc: any, { _id, total }: any) => {
-      acc[_id] = {
+      const name = _id ? _id.split(" ").map((w: string) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join(" ") : "";
+      acc[name] = {
         amount: convertToDollarUnit(total),
         percentage:
-          totalExpenses > 0 ? Math.round((total / totalExpenses) * 100) : 0,
+          totalExpenses > 0 ? Number(((total / totalExpenses) * 100).toFixed(1)) : 0,
       };
       return acc;
     },


### PR DESCRIPTION
## Summary

This PR fixes duplicate category labels in the analytics data and increases percentage precision:
1. **Case-insensitive category grouping**: MongoDB aggregations in `analytics.service.ts` and `report.service.ts` now group category names using `{ $toLower: "$category" }` to prevent separate entries for different casings (e.g. `"groceries"` vs `"Groceries"`).
2. **Formatting names**: Capitalizes the first letter of each word in the output category keys (e.g., `"dining & restaurants"` becomes `"Dining & Restaurants"`).
3. **Decimal precision**: Changed rounding from `0` to `2` decimal places in `analytics.service.ts` and from integer to one decimal place in `report.service.ts` so the client receives enough precision for accurate rendering.

## Related issues

- Closes #142 
## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [ ] ui (components / pages)
- [ ] design (tokens / styles)
- [x] server (endpoints / services / DB)
- [ ] CI/CD
- [ ] docs

## How to test

1. Seed the database with transactions containing different casings of the same category (e.g., "transport" and "Transport").
2. Query the analytics endpoints (`GET /api/analytics/category-breakdown`).
3. Confirm that the response groups them together case-insensitively and returns the percentage with 2 decimal places.

## Screenshot 
<img width="215" height="350" alt="image" src="https://github.com/user-attachments/assets/e05e9df2-5b08-4146-8925-ad0291913a82" />

## Validation output

```
# backend
npm run build && npm test --if-present

> backend@1.2.0 build
> tsc
```

