### PR TITLE
fix: Production hardening — auth revocation, atomic budget writes, rate-limit fix

### DIFF
--- a/src/controllers/analytics.controller.ts
+++ b/src/controllers/analytics.controller.ts
@@ -58,6 +58,52 @@ export const chartAnalyticsController = asyncHandler(
   }
 );
 
+/**
+ * Combined dashboard payload: summary + chart + expense breakdown in one
+ * request. The mobile dashboard previously made three separate calls (three
+ * serverless invocations, three cold-start exposures); here the three
+ * aggregations run concurrently on one warm connection. The individual
+ * endpoints remain unchanged for existing clients.
+ */
+export const dashboardAnalyticsController = asyncHandler(
+  async (req: Request, res: Response) => {
+    const userId = req.user?._id;
+    const { preset, from, to } = req.query;
+
+    const filter = {
+      dateRangePreset: preset as DateRangePreset,
+      customFrom: from ? new Date(from as string) : undefined,
+      customTo: to ? new Date(to as string) : undefined,
+    };
+
+    const [summary, chart, expenseBreakdown] = await Promise.all([
+      summaryAnalyticsService(
+        userId,
+        filter.dateRangePreset,
+        filter.customFrom,
+        filter.customTo
+      ),
+      chartAnalyticsService(
+        userId,
+        filter.dateRangePreset,
+        filter.customFrom,
+        filter.customTo
+      ),
+      expensePieChartBreakdownService(
+        userId,
+        filter.dateRangePreset,
+        filter.customFrom,
+        filter.customTo
+      ),
+    ]);
+
+    return res.status(HTTPSTATUS.OK).json({
+      message: "Dashboard analytics fetched successfully",
+      data: { summary, chart, expenseBreakdown },
+    });
+  }
+);
+
 export const expensePieChartBreakdownController = asyncHandler(
   async (req: Request, res: Response) => {
     const userId = req.user?._id;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,11 @@ import currencyRoutes from "./routes/currency.route";
 const app = express();
 const BASE_PATH = Env.BASE_PATH;
 
+// Behind Vercel's proxy, req.ip is the load balancer unless trust proxy is
+// set — which made the per-IP rate limiters share one bucket across unrelated
+// users (legitimate 429 lockouts) while under-counting real clients.
+app.set("trust proxy", 1);
+
 // PERF: response-time instrumentation must wrap every request — register first,
 // before body parsing and routes, so it captures the full request lifetime.
 app.use(performanceLogger);
@@ -57,8 +62,10 @@ const corsOptions = {
   credentials: true,
 };
 
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
+// 2mb (default 100kb) so bulk transaction imports of a few hundred rows don't
+// fail with an opaque 413.
+app.use(express.json({ limit: "2mb" }));
+app.use(express.urlencoded({ extended: true, limit: "2mb" }));
 
 app.use(passport.initialize());
 

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -17,6 +17,11 @@ export interface UserDocument extends Document {
   passwordResetOtpHash?: string | null;
   passwordResetOtpExpiresAt?: Date | null;
   lastOtpResentAt?: Date | null;
+  /**
+   * Refresh-token generation counter. Incrementing it invalidates every
+   * refresh token issued before the bump (used on password reset/change).
+   */
+  tokenVersion: number;
   customCategories?: { value: string; label: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -94,6 +99,10 @@ const userSchema = new Schema<UserDocument>(
       select: false,
       default: null,
     },
+    tokenVersion: {
+      type: Number,
+      default: 0,
+    },
     customCategories: {
       type: [
         {
@@ -125,6 +134,7 @@ userSchema.methods.omitPassword = function (): Omit<UserDocument, "password"> {
   delete userObject.emailVerificationOtpExpiresAt;
   delete userObject.passwordResetOtpHash;
   delete userObject.passwordResetOtpExpiresAt;
+  delete userObject.tokenVersion;
   return userObject;
 };
 

--- a/src/routes/analytics.route.ts
+++ b/src/routes/analytics.route.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import {
   chartAnalyticsController,
+  dashboardAnalyticsController,
   expensePieChartBreakdownController,
   summaryAnalyticsController,
 } from "../controllers/analytics.controller";
@@ -10,5 +11,6 @@ const analyticsRoutes = Router();
 analyticsRoutes.get("/summary", summaryAnalyticsController);
 analyticsRoutes.get("/chart", chartAnalyticsController);
 analyticsRoutes.get("/expense-breakdown", expensePieChartBreakdownController);
+analyticsRoutes.get("/dashboard", dashboardAnalyticsController);
 
 export default analyticsRoutes;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -179,7 +179,10 @@ export const loginService = async (body: LoginSchemaType) => {
   }
 
   const { token, expiresAt } = signJwtToken({ userId: user.id });
-  const refreshToken = signRefreshToken({ userId: user.id });
+  const refreshToken = signRefreshToken({
+    userId: user.id,
+    tokenVersion: user.tokenVersion ?? 0,
+  });
 
   const reportSetting = await ReportSettingModel.findOne(
     { userId: user.id },
@@ -261,7 +264,10 @@ export const verifyOtpService = async (body: VerifyOtpSchemaType) => {
 
   // Auto-login: Generate JWT tokens
   const { token, expiresAt } = signJwtToken({ userId: verificationUser.id });
-  const refreshToken = signRefreshToken({ userId: verificationUser.id });
+  const refreshToken = signRefreshToken({
+    userId: verificationUser.id,
+    tokenVersion: verificationUser.tokenVersion ?? 0,
+  });
 
   const reportSetting = await ReportSettingModel.findOne(
     {
@@ -404,6 +410,9 @@ export const resetPasswordService = async (body: ResetPasswordSchemaType) => {
     password,
     passwordResetOtpHash: null,
     passwordResetOtpExpiresAt: null,
+    // Revoke every previously issued refresh token — a password reset must
+    // sign out any device (or attacker) still holding an old session.
+    tokenVersion: (user.tokenVersion ?? 0) + 1,
   });
 
   await user.save();
@@ -414,7 +423,7 @@ export const resetPasswordService = async (body: ResetPasswordSchemaType) => {
 };
 
 export const refreshTokenService = async (refreshToken: string) => {
-  let payload: { userId: string };
+  let payload: { userId: string; tokenVersion?: number };
   try {
     payload = verifyRefreshToken(refreshToken);
   } catch (error) {
@@ -438,8 +447,21 @@ export const refreshTokenService = async (refreshToken: string) => {
     );
   }
 
+  // Tokens signed before the version bump (e.g. before a password reset) are
+  // revoked. Tokens issued before this field existed carry no claim — treat
+  // them as version 0 so existing sessions keep working.
+  if ((payload.tokenVersion ?? 0) !== (user.tokenVersion ?? 0)) {
+    throw new UnauthorizedException(
+      "Refresh token has been revoked. Please sign in again.",
+      ErrorCodeEnum.AUTH_REFRESH_TOKEN_INVALID,
+    );
+  }
+
   const { token: accessToken, expiresAt } = signJwtToken({ userId: user.id });
-  const nextRefreshToken = signRefreshToken({ userId: user.id });
+  const nextRefreshToken = signRefreshToken({
+    userId: user.id,
+    tokenVersion: user.tokenVersion ?? 0,
+  });
 
   const reportSetting = await ReportSettingModel.findOne(
     { userId: user.id },

--- a/src/services/category.service.ts
+++ b/src/services/category.service.ts
@@ -30,9 +30,15 @@ const DEFAULT_CATEGORIES = [
 ];
 
 export const getCategoriesService = async (userId: string) => {
-  const existingCount = await CategoryModel.countDocuments({ userId });
+  // PERF: fetch first and seed only when the user has no categories at all,
+  // so the common case is a single indexed query instead of count + find.
+  // This path also runs inside the voice/receipt AI flows, so it's hot.
+  let categories = await CategoryModel.find({ userId }).sort({
+    isDefault: -1,
+    name: 1,
+  });
 
-  if (existingCount === 0) {
+  if (categories.length === 0) {
     await CategoryModel.insertMany(
       DEFAULT_CATEGORIES.map((cat) => ({
         userId,
@@ -41,12 +47,11 @@ export const getCategoriesService = async (userId: string) => {
         isDefault: true,
       }))
     );
+    categories = await CategoryModel.find({ userId }).sort({
+      isDefault: -1,
+      name: 1,
+    });
   }
-
-  const categories = await CategoryModel.find({ userId }).sort({
-    isDefault: -1,
-    name: 1,
-  });
 
   // Self-heal: purge any junk categories that leaked in from older clients
   // (e.g. a category literally named "undefined") so they never show again.

--- a/src/services/google-auth.service.ts
+++ b/src/services/google-auth.service.ts
@@ -73,7 +73,10 @@ export const googleAuthService = async (body: GoogleAuthSchemaType) => {
       if (user) {
         // User already has Google OAuth linked
         const { token, expiresAt } = signJwtToken({ userId: user.id });
-        const refreshToken = signRefreshToken({ userId: user.id });
+        const refreshToken = signRefreshToken({
+          userId: user.id,
+          tokenVersion: user.tokenVersion ?? 0,
+        });
 
         const reportSetting = await ReportSettingModel.findOne(
           { userId: user.id },
@@ -108,7 +111,10 @@ export const googleAuthService = async (body: GoogleAuthSchemaType) => {
         await user.save({ session });
 
         const { token, expiresAt } = signJwtToken({ userId: user.id });
-        const refreshToken = signRefreshToken({ userId: user.id });
+        const refreshToken = signRefreshToken({
+          userId: user.id,
+          tokenVersion: user.tokenVersion ?? 0,
+        });
 
         const reportSetting = await ReportSettingModel.findOne(
           { userId: user.id },
@@ -144,7 +150,10 @@ export const googleAuthService = async (body: GoogleAuthSchemaType) => {
       await createDefaultReportSetting(newUser._id as mongoose.Types.ObjectId, session);
 
       const { token, expiresAt } = signJwtToken({ userId: newUser.id });
-      const refreshToken = signRefreshToken({ userId: newUser.id });
+      const refreshToken = signRefreshToken({
+        userId: newUser.id,
+        tokenVersion: newUser.tokenVersion ?? 0,
+      });
 
       const reportSetting = await ReportSettingModel.findOne(
         { userId: newUser.id },

--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -1,3 +1,4 @@
+import mongoose from "mongoose";
 import TransactionModel, {
   TransactionTypeEnum,
 } from "../models/transaction.model";
@@ -94,66 +95,7 @@ export const createTransactionService = async (
     body.currency,
   );
 
-  if (body.type === TransactionTypeEnum.EXPENSE) {
-    const transactionDate = new Date(body.date);
-    const month = transactionDate.getMonth() + 1;
-    const year = transactionDate.getFullYear();
-
-    const budget = await BudgetModel.findOne({
-      userId,
-      month,
-      year,
-    });
-
-    if (budget) {
-      // Calculate current total spent for this month/year
-      const startDate = new Date(year, month - 1, 1);
-      const endDate = new Date(year, month, 0, 23, 59, 59, 999);
-      const transactions = await TransactionModel.find({
-        userId,
-        type: TransactionTypeEnum.EXPENSE,
-        date: {
-          $gte: startDate,
-          $lte: endDate,
-        },
-      }).select("amount category"); // PERF: only the fields the budget sum needs
-
-      const totalSpent = transactions.reduce((sum, t) => sum + (typeof t.amount === 'number' ? t.amount : parseFloat(String(t.amount || 0))), 0);
-
-      if (totalSpent + currencyFields.amount > budget.totalBudget) {
-        const remaining = budget.totalBudget - totalSpent;
-        const remainingStr = remaining < 0 ? `-$${Math.abs(remaining).toFixed(2)}` : `$${remaining.toFixed(2)}`;
-        throw new BadRequestException(
-          `Transaction exceeds monthly budget of $${budget.totalBudget}. Remaining: ${remainingStr}`,
-          ErrorCodeEnum.BUDGET_INVALID_AMOUNT
-        );
-      }
-
-      // Check category limit
-      if (body.category) {
-        const normalizedCategory = body.category.trim().toLowerCase().replace(/\s+/g, "_");
-        const categoryLimit = budget.categoryLimits.find(
-          (c) => c.category.trim().toLowerCase().replace(/\s+/g, "_") === normalizedCategory
-        );
-        if (categoryLimit) {
-          const categorySpent = transactions
-            .filter((t) => t.category.trim().toLowerCase().replace(/\s+/g, "_") === normalizedCategory)
-            .reduce((sum, t) => sum + (typeof t.amount === 'number' ? t.amount : parseFloat(String(t.amount || 0))), 0);
-
-          if (categorySpent + currencyFields.amount > categoryLimit.limit) {
-            const remaining = categoryLimit.limit - categorySpent;
-            const remainingStr = remaining < 0 ? `-$${Math.abs(remaining).toFixed(2)}` : `$${remaining.toFixed(2)}`;
-            throw new BadRequestException(
-              `Transaction exceeds category limit for ${body.category}. Remaining: ${remainingStr}`,
-              ErrorCodeEnum.BUDGET_INVALID_AMOUNT
-            );
-          }
-        }
-      }
-    }
-  }
-
-  const transaction = await TransactionModel.create({
+  const transactionDoc = {
     ...body,
     userId,
     category: body.category,
@@ -168,9 +110,112 @@ export const createTransactionService = async (
     recurringInterval: body.recurringInterval || null,
     nextRecurringDate,
     lastProcessed: null,
-  });
+  };
 
-  return transaction;
+  if (body.type !== TransactionTypeEnum.EXPENSE) {
+    return TransactionModel.create(transactionDoc);
+  }
+
+  // Expense: validate against the budget and insert atomically. Without a
+  // transaction, two concurrent expense writes can both read the same spend
+  // total, both pass validation, and jointly exceed the budget (check-then-act
+  // race). Snapshot reads + the insert now commit together; a validation
+  // failure aborts the transaction. Requires a replica set (all Atlas tiers).
+  const session = await mongoose.startSession();
+  try {
+    let created: Awaited<ReturnType<typeof TransactionModel.create>>[number] | undefined;
+
+    await session.withTransaction(async () => {
+      await validateExpenseAgainstBudget(
+        userId,
+        new Date(body.date),
+        currencyFields.amount,
+        body.category,
+        session,
+      );
+
+      const [doc] = await TransactionModel.create([transactionDoc], { session });
+      created = doc;
+    });
+
+    return created!;
+  } finally {
+    await session.endSession();
+  }
+};
+
+/**
+ * Throws BUDGET_INVALID_AMOUNT when adding `amount` would exceed the monthly
+ * budget or the matching category limit. `excludeTransactionId` omits the
+ * transaction being updated from the current-spend calculation. All reads run
+ * inside the caller's session so validation and write commit atomically.
+ */
+const validateExpenseAgainstBudget = async (
+  userId: string,
+  transactionDate: Date,
+  amount: number,
+  category: string | undefined,
+  session: mongoose.ClientSession,
+  excludeTransactionId?: string,
+) => {
+  const month = transactionDate.getMonth() + 1;
+  const year = transactionDate.getFullYear();
+
+  const budget = await BudgetModel.findOne({
+    userId,
+    month,
+    year,
+  }).session(session);
+
+  if (!budget) return;
+
+  // Calculate current total spent for this month/year
+  const startDate = new Date(year, month - 1, 1);
+  const endDate = new Date(year, month, 0, 23, 59, 59, 999);
+  const transactions = await TransactionModel.find({
+    userId,
+    ...(excludeTransactionId && { _id: { $ne: excludeTransactionId } }),
+    type: TransactionTypeEnum.EXPENSE,
+    date: {
+      $gte: startDate,
+      $lte: endDate,
+    },
+  })
+    .select("amount category") // PERF: only the fields the budget sum needs
+    .session(session);
+
+  const totalSpent = transactions.reduce((sum, t) => sum + (typeof t.amount === 'number' ? t.amount : parseFloat(String(t.amount || 0))), 0);
+
+  if (totalSpent + amount > budget.totalBudget) {
+    const remaining = budget.totalBudget - totalSpent;
+    const remainingStr = remaining < 0 ? `-$${Math.abs(remaining).toFixed(2)}` : `$${remaining.toFixed(2)}`;
+    throw new BadRequestException(
+      `Transaction exceeds monthly budget of $${budget.totalBudget}. Remaining: ${remainingStr}`,
+      ErrorCodeEnum.BUDGET_INVALID_AMOUNT
+    );
+  }
+
+  // Check category limit
+  if (category) {
+    const normalizedCategory = category.trim().toLowerCase().replace(/\s+/g, "_");
+    const categoryLimit = budget.categoryLimits.find(
+      (c) => c.category.trim().toLowerCase().replace(/\s+/g, "_") === normalizedCategory
+    );
+    if (categoryLimit) {
+      const categorySpent = transactions
+        .filter((t) => t.category.trim().toLowerCase().replace(/\s+/g, "_") === normalizedCategory)
+        .reduce((sum, t) => sum + (typeof t.amount === 'number' ? t.amount : parseFloat(String(t.amount || 0))), 0);
+
+      if (categorySpent + amount > categoryLimit.limit) {
+        const remaining = categoryLimit.limit - categorySpent;
+        const remainingStr = remaining < 0 ? `-$${Math.abs(remaining).toFixed(2)}` : `$${remaining.toFixed(2)}`;
+        throw new BadRequestException(
+          `Transaction exceeds category limit for ${category}. Remaining: ${remainingStr}`,
+          ErrorCodeEnum.BUDGET_INVALID_AMOUNT
+        );
+      }
+    }
+  }
 };
 
 export const getAllTransactionService = async (
@@ -399,83 +444,50 @@ export const updateTransactionService = async (
   }
 
   const targetType = body.type || existingTransaction.type;
-  if (targetType === TransactionTypeEnum.EXPENSE) {
-    const transactionDate = new Date(date);
-    const month = transactionDate.getMonth() + 1;
-    const year = transactionDate.getFullYear();
 
-    const budget = await BudgetModel.findOne({
-      userId,
-      month,
-      year,
+  const applyUpdate = async (session?: mongoose.ClientSession) => {
+    existingTransaction.set({
+      ...(body.title && { title: body.title }),
+      ...(body.description && { description: body.description }),
+      ...(body.category && { category: body.category }),
+      ...(body.type && { type: body.type }),
+      ...(body.paymentMethod && { paymentMethod: body.paymentMethod }),
+      ...currencyUpdate,
+      date,
+      isRecurring,
+      recurringInterval,
+      nextRecurringDate,
     });
+    await existingTransaction.save({ session });
+  };
 
-    if (budget) {
-      const targetAmount = currencyUpdate.amount !== undefined ? currencyUpdate.amount : existingTransaction.amount;
-
-      // Calculate current total spent for this month/year, excluding this transaction
-      const startDate = new Date(year, month - 1, 1);
-      const endDate = new Date(year, month, 0, 23, 59, 59, 999);
-      const transactions = await TransactionModel.find({
-        userId,
-        _id: { $ne: transactionId },
-        type: TransactionTypeEnum.EXPENSE,
-        date: {
-          $gte: startDate,
-          $lte: endDate,
-        },
-      }).select("amount category"); // PERF: only the fields the budget sum needs
-
-      const totalSpent = transactions.reduce((sum, t) => sum + (typeof t.amount === 'number' ? t.amount : parseFloat(String(t.amount || 0))), 0);
-
-      if (totalSpent + targetAmount > budget.totalBudget) {
-        const remaining = budget.totalBudget - totalSpent;
-        const remainingStr = remaining < 0 ? `-$${Math.abs(remaining).toFixed(2)}` : `$${remaining.toFixed(2)}`;
-        throw new BadRequestException(
-          `Transaction exceeds monthly budget of $${budget.totalBudget}. Remaining: ${remainingStr}`,
-          ErrorCodeEnum.BUDGET_INVALID_AMOUNT
-        );
-      }
-
-      // Check category limit
-      const category = body.category || existingTransaction.category;
-      if (category) {
-        const normalizedCategory = category.trim().toLowerCase().replace(/\s+/g, "_");
-        const categoryLimit = budget.categoryLimits.find(
-          (c) => c.category.trim().toLowerCase().replace(/\s+/g, "_") === normalizedCategory
-        );
-        if (categoryLimit) {
-          const categorySpent = transactions
-            .filter((t) => t.category.trim().toLowerCase().replace(/\s+/g, "_") === normalizedCategory)
-            .reduce((sum, t) => sum + (typeof t.amount === 'number' ? t.amount : parseFloat(String(t.amount || 0))), 0);
-
-          if (categorySpent + targetAmount > categoryLimit.limit) {
-            const remaining = categoryLimit.limit - categorySpent;
-            const remainingStr = remaining < 0 ? `-$${Math.abs(remaining).toFixed(2)}` : `$${remaining.toFixed(2)}`;
-            throw new BadRequestException(
-              `Transaction exceeds category limit for ${category}. Remaining: ${remainingStr}`,
-              ErrorCodeEnum.BUDGET_INVALID_AMOUNT
-            );
-          }
-        }
-      }
-    }
+  if (targetType !== TransactionTypeEnum.EXPENSE) {
+    await applyUpdate();
+    return;
   }
 
-  existingTransaction.set({
-    ...(body.title && { title: body.title }),
-    ...(body.description && { description: body.description }),
-    ...(body.category && { category: body.category }),
-    ...(body.type && { type: body.type }),
-    ...(body.paymentMethod && { paymentMethod: body.paymentMethod }),
-    ...currencyUpdate,
-    date,
-    isRecurring,
-    recurringInterval,
-    nextRecurringDate,
-  });
+  // Same check-then-act protection as create: validate + save atomically.
+  const targetAmount =
+    currencyUpdate.amount !== undefined
+      ? currencyUpdate.amount
+      : existingTransaction.amount;
 
-  await existingTransaction.save();
+  const session = await mongoose.startSession();
+  try {
+    await session.withTransaction(async () => {
+      await validateExpenseAgainstBudget(
+        userId,
+        new Date(date),
+        targetAmount,
+        body.category || existingTransaction.category,
+        session,
+        transactionId,
+      );
+      await applyUpdate(session);
+    });
+  } finally {
+    await session.endSession();
+  }
 
   return;
 };

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -10,6 +10,12 @@ export type AccessTokenPayload = {
 
 export type RefreshTokenPayload = {
   userId: string;
+  /**
+   * Matches the user's current tokenVersion; bumping the user's version
+   * revokes every previously issued refresh token. Absent on tokens issued
+   * before this field existed — treated as version 0 for backward compat.
+   */
+  tokenVersion?: number;
 };
 
 type SignOptsAndSecret = SignOptions & {
@@ -75,5 +81,5 @@ export const verifyRefreshToken = (token: string): RefreshTokenPayload => {
     throw new jwt.JsonWebTokenError("Missing userId in refresh token payload");
   }
 
-  return { userId: decoded.userId };
+  return { userId: decoded.userId, tokenVersion: decoded.tokenVersion };
 };


### PR DESCRIPTION
Production-readiness fixes plus two approved performance changes. No API contract changes except one additive endpoint.

**Security & reliability**
- `trust proxy` — the per-IP rate limiters were keying on the load-balancer address behind Vercel, sharing one bucket across unrelated users (legit 429 lockouts) while under-counting real clients.
- Refresh-token revocation via per-user `tokenVersion` — a password reset now signs out every previously issued session. Backward compatible: tokens without the claim are treated as version 0, so **existing users stay logged in**. No DB migration needed (Mongoose default).
- Budget validation + expense write now run in a MongoDB transaction, closing the check-then-act race where concurrent expenses could jointly exceed a budget. Requires a replica set (all Atlas tiers).
- JSON body limit raised to 2mb so bulk imports don't fail with an opaque 413.

**Performance**
- New additive `GET /analytics/dashboard` returns summary + chart + expense breakdown in one invocation (mobile previously made three). Individual endpoints unchanged for web.
- `getCategoriesService` skips the count query when categories exist (single indexed query on a path that's also hot in the voice/receipt AI flows).

**Deploy note:** merge/deploy this before the mobile app update that consumes `/analytics/dashboard` (Vercel deploys on merge; the mobile binary ships later via EAS, so ordering is naturally safe).

Indexes verified unchanged and correct for all query shapes. `tsc` clean.