### PR TITLE
fix: Reject unsupported image uploads instead of hanging

### DIFF
--- a/src/config/cloudinary.config.ts
+++ b/src/config/cloudinary.config.ts
@@ -1,7 +1,12 @@
 import { v2 as cloudinary } from "cloudinary";
 import { CloudinaryStorage } from "multer-storage-cloudinary";
-import { Env } from "./env.config";
 import multer from "multer";
+
+import { ErrorCodeEnum } from "../enums/error-code.enum";
+import { AppError } from "../utils/app-error";
+
+import { Env } from "./env.config";
+import { HTTPSTATUS } from "./http.config";
 
 cloudinary.config({
   cloud_name: Env.CLOUDINARY_CLOUD_NAME,
@@ -29,7 +34,16 @@ export const upload = multer({
   fileFilter: (_, file, cb) => {
     const isValid = /^image\/(jpe?g|png)$/.test(file.mimetype);
     if (!isValid) {
-      return;
+      // Must signal rejection through the callback. Returning without calling
+      // it leaves Multer waiting on a callback that never arrives, so the
+      // request hangs until the client or platform times out.
+      return cb(
+        new AppError(
+          "Only JPG, JPEG and PNG images are supported",
+          HTTPSTATUS.BAD_REQUEST,
+          ErrorCodeEnum.FILE_UPLOAD_ERROR,
+        ),
+      );
     }
 
     cb(null, true);


### PR DESCRIPTION
## Summary

Multer's `fileFilter` in `src/config/cloudinary.config.ts` returned early when a
file's mimetype was not `jpg`/`jpeg`/`png`, **without ever calling its callback**:

```ts
const isValid = /^image\/(jpe?g|png)$/.test(file.mimetype);
if (!isValid) {
  return;          // callback never invoked
}
cb(null, true);
```

Multer waits on that callback before continuing, so the request never completes.
It hangs until the client gives up or the platform kills it, instead of failing
fast. On Vercel every rejected upload burns the function's full `maxDuration`
(60s) while holding a connection.

This signals rejection through the callback, so the request terminates
immediately with a `400` and an actionable message. It mirrors how the voice
upload filter already rejects unsupported audio types.

Affected routes:

- `PUT /api/user/update` (`profilePicture`)
- `POST /api/transaction/scan-receipt` (`receipt`)

No change to the accepted-file path: valid JPG/JPEG/PNG uploads behave exactly as
before.

## Related issues

- Closes #
- Related to # — no tracking issue; found while auditing upload handling.

## Issue template used

- [ ] Bug report
- [ ] Feature request
- [ ] Question
- [x] Other — proactive fix, no pre-existing issue

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] backend
- [ ] client (web)
- [ ] mobile (React Native)
- [ ] CI/CD
- [ ] docs

## How to test

```bash
cd backend && npm ci && npm run dev
```

Send a non-image as the upload field with a valid bearer token:

```bash
printf 'not an image\n' > bad.txt

curl -i -X PUT http://localhost:8000/api/user/update \
  -H "Authorization: Bearer <token>" \
  -F "profilePicture=@bad.txt;type=text/plain"
```

**Before:** the request hangs indefinitely (no response, no status).
**After:** returns immediately with

```json
{"message":"Only JPG, JPEG and PNG images are supported","errorCode":"FILE_UPLOAD_ERROR"}
```

Repeat against `POST /api/transaction/scan-receipt` with `-F "receipt=@bad.txt;type=text/plain"`.

Then confirm the happy path is unchanged by uploading a real `.png` — it still
returns `200` with a `cloudinary.com` URL.

## Media

- [ ] I attached screenshots or recordings when the change affects the UI or visible behavior.
- [ ] I linked the issue or discussion that motivated this change.

Not applicable — no UI change; request/response samples are included above.

## Validation output

```
# backend
$ npm run build
> backend@1.2.0 build
> tsc
(exit 0)

$ npm test --if-present
(no test script defined — skipped)
```

Manual verification against a running server:

```
PUT  /api/user/update              (text/plain) -> 400 in 2.0s   {"message":"Only JPG, JPEG and PNG images are supported","errorCode":"FILE_UPLOAD_ERROR"}
POST /api/transaction/scan-receipt (text/plain) -> 400 in 0.15s  {"message":"Only JPG, JPEG and PNG images are supported","errorCode":"FILE_UPLOAD_ERROR"}
POST /api/transaction/scan-receipt (image/png)  -> 200           receipt uploaded to Cloudinary, scan returned
```

## Screenshots or recordings

Not applicable — backend-only change.

## Breaking changes

- [x] No
- [ ] Yes (describe below)

A request that previously hung now returns `400`. Any client relying on the hang
was already timing out, so there is no working behaviour to preserve.

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed — the repo has no test harness; verified manually (output above).
- [ ] I updated documentation where needed — no documented behaviour changes.
- [x] I removed secrets and sensitive information.
