### PR TITLE
fix: Escape search keywords before building the transaction query

### DIFF
--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -16,6 +16,29 @@ import { voiceConfig } from "../config/voice.config";
 import { resolveUserCurrencyConversion } from "./currency-conversion.service";
 import UserModel from "../models/user.model";
 import { resolveCurrencyConversion } from "./currency-conversion.service";
+
+/**
+ * Escape every regular-expression metacharacter so a search term is matched
+ * literally.
+ *
+ * Interpolating a raw term into `$regex` lets the caller supply a pattern
+ * rather than a keyword. A crafted term such as `(a+)+$` triggers catastrophic
+ * backtracking in the database's regex engine, tying up a connection until the
+ * query is killed, and characters like `.` silently widen matches.
+ */
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Force a query-string value to a primitive string.
+ *
+ * Express parses bracket notation (`?type[$ne]=EXPENSE`) into a nested object.
+ * Assigned straight into a filter, that turns a value the caller controls into a
+ * query operator; coercing first keeps it an inert string.
+ */
+const asQueryString = (value: unknown): string =>
+  typeof value === "string" ? value : String(value);
+
 /**
  * Sanitize and validate pagination inputs to prevent abuse and crashes
  * @param pageSize - requested page size (can be string, number, or invalid)
@@ -239,14 +262,15 @@ export const getAllTransactionService = async (
   };
 
   if (keyword) {
+    const safeKeyword = escapeRegExp(asQueryString(keyword));
     filterConditions.$or = [
-      { title: { $regex: keyword, $options: "i" } },
-      { category: { $regex: keyword, $options: "i" } },
+      { title: { $regex: safeKeyword, $options: "i" } },
+      { category: { $regex: safeKeyword, $options: "i" } },
     ];
   }
 
   if (type) {
-    filterConditions.type = type;
+    filterConditions.type = asQueryString(type);
   }
 
   if (recurringStatus) {
@@ -258,10 +282,10 @@ export const getAllTransactionService = async (
   }
 
   if (startDate || endDate) {
-    const start = startDate ? new Date(startDate) : null;
+    const start = startDate ? new Date(asQueryString(startDate)) : null;
     let end: Date | null = null;
     if (endDate) {
-      end = new Date(endDate);
+      end = new Date(asQueryString(endDate));
       end.setHours(23, 59, 59, 999);
     }
 


### PR DESCRIPTION
## Summary

`getAllTransactionService` built its MongoDB filter from raw query-string values.

**1. Unescaped `$regex` (ReDoS) — high severity**

```ts
filterConditions.$or = [
  { title:    { $regex: keyword, $options: "i" } },   // keyword is raw user input
  { category: { $regex: keyword, $options: "i" } },
];
```

The caller supplies a *pattern*, not a search term. A keyword like `(a+)+$`
causes catastrophic backtracking. Measured locally against a field of N `a`
characters:

| field length | escaped | unescaped |
| --- | --- | --- |
| 18 | 0.039 ms | 53 ms |
| 22 | 0.022 ms | 79 ms |
| 24 | 0.017 ms | 341 ms |
| 26 | 0.040 ms | **2 666 ms** |
| 32 | — | **did not finish in 180 s** |

Every extra two characters roughly quadruples the time, so a single request can
pin a database connection until the query is killed. On Vercel it also burns the
function's full `maxDuration`. No authentication bypass is involved — any signed-in
user can do this to the shared database.

Separately, `.` and `*` in an ordinary keyword silently widened matches (`a.b`
matched `axb`).

**2. Operator injection via bracket notation — lower impact**

Express parses `?type[$ne]=EXPENSE` into `{ $ne: "EXPENSE" }`, which was assigned
straight into the filter, turning a caller-controlled value into a query
operator. Blast radius was limited — `userId` is always part of the filter, so
there is **no cross-account access** — but the filter was still steerable.

### The fix

Two small helpers, applied at the point the filter is built:

- `escapeRegExp()` — escapes regex metacharacters so the term matches literally.
- `asQueryString()` — coerces a query value to a primitive string, so bracket
  notation can no longer smuggle in an operator.

Ordinary keywords are completely unaffected (`coffee` → `coffee`,
`Uber Eats` → `Uber Eats`).

Found by CodeQL (`js/sql-injection`, 2× high) at the `find` /
`countDocuments` sinks. It surfaced while reviewing an unrelated refactor, but
the bug is present on `main` today, which is why this is a standalone PR.

## Related issues

- Closes #
- Related to # — surfaced by CodeQL while working on #165; not previously tracked.

## Issue template used

- [ ] Bug report
- [ ] Feature request
- [ ] Question
- [x] Other — security finding from CodeQL, no pre-existing issue

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] backend
- [ ] client (web)
- [ ] mobile (React Native)
- [ ] CI/CD
- [ ] docs

## How to test

```bash
cd backend && npm ci && npm run dev
```

Confirm ordinary search still works:

```bash
curl "http://localhost:8000/api/transaction/all?pageSize=20&pageNumber=1&keyword=coffee" \
  -H "Authorization: Bearer <token>"
```

Confirm the ReDoS keyword now returns promptly instead of stalling:

```bash
time curl "http://localhost:8000/api/transaction/all?pageSize=20&pageNumber=1&keyword=%28a%2B%29%2B%24" \
  -H "Authorization: Bearer <token>"
```

Confirm the operator can no longer reach the filter (returns an empty result set
rather than inverting the type filter):

```bash
curl "http://localhost:8000/api/transaction/all?pageSize=20&pageNumber=1&type[\$ne]=EXPENSE" \
  -H "Authorization: Bearer <token>"
```

## Media

- [ ] I attached screenshots or recordings when the change affects the UI or visible behavior.
- [ ] I linked the issue or discussion that motivated this change.

Not applicable — backend-only. Timings and payloads are included above.

## Validation output

```
# backend
$ npm run build
> backend@1.2.0 build
> tsc
(exit 0)

$ npx tsc --noEmit
(exit 0)

$ npm test --if-present
(no test script defined — skipped)
```

Escaping and coercion behaviour:

```
=== ReDoS: catastrophic backtracking ===
  raw keyword     : (a+)+$
  escaped keyword : \(a\+\)\+\$

   N   escaped     unescaped
  18     0.039ms        53ms
  20     0.018ms        18ms
  22     0.022ms        79ms
  24     0.017ms       341ms
  26     0.040ms      2666ms

=== NoSQL operator injection ===
  ?type[$ne]=EXPENSE parses to : {"$ne":"EXPENSE"}
  raw     -> filter.type = {"$ne":"EXPENSE"} (an operator)
  coerced -> filter.type = "[object Object]"

=== ordinary keywords unchanged ===
  "coffee"    -> "coffee"
  "Uber Eats" -> "Uber Eats"
  "rent 2026" -> "rent 2026"
```

## Screenshots or recordings

Not applicable — backend-only change.

## Breaking changes

- [x] No
- [ ] Yes (describe below)

One intentional behaviour change worth noting in review: **regex metacharacters
in a keyword now match literally.** Searching `a.b` previously matched `axb`;
it now matches only a literal `a.b`. This is the intended behaviour for a
keyword search, and no client documents or relies on regex search syntax.

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed — the repo has no test harness; `escapeRegExp` / `asQueryString` are pure functions and would be the easiest possible first unit tests if one is added.
- [ ] I updated documentation where needed — no documented behaviour changes.
- [x] I removed secrets and sensitive information.
